### PR TITLE
Add GIF selection functionality to Stimulus controller

### DIFF
--- a/app/javascript/controllers/select_gif_controller.js
+++ b/app/javascript/controllers/select_gif_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["gifUrl"]
+
+  selectGif(event) {
+    const gifUrl = event.target.src;
+    const inputElement = document.getElementById("moment_gif_url");
+    if (inputElement) {
+        inputElement.value = gifUrl;
+    }
+  }
+}

--- a/app/views/moments/_search_gif.html.erb
+++ b/app/views/moments/_search_gif.html.erb
@@ -1,6 +1,6 @@
-<div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4">
+<div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4" data-controller="select-gif">
   <% @gifs&.each do |gif| %>
-    <div class="mb-4">
+    <div class="mb-4" data-action="click->select-gif#selectGif" data-gif-url="<%= gif[:tinygif] %>">
       <%= image_tag gif[:tinygif], class: "rounded-lg" %>
     </div>
   <% end %>


### PR DESCRIPTION
This pull request adds functionality to the application that allows users to select a GIF from the search results and automatically populate the GIF URL input field in the "moments" form. The changes include the addition of a Stimulus controller named select_gif_controller.js, which listens for clicks on GIF images in the search results and updates the input field with the URL of the selected GIF.

Changes:

Added select_gif_controller.js to handle GIF selection functionality.
Updated the search results view (_search_gif.html.erb) to include necessary data attributes and targets for the Stimulus controller.

This feature enhances user experience by simplifying the process of selecting and adding GIFs to moments.