### PR TITLE
Do not show URL field

### DIFF
--- a/app/javascript/controllers/select_gif_controller.js
+++ b/app/javascript/controllers/select_gif_controller.js
@@ -1,13 +1,22 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["gifUrl"]
+  static targets = ["gif"]
+  static values = { url: String }
 
-  selectGif(event) {
-    const gifUrl = event.target.src;
+  selectGif() {
     const inputElement = document.getElementById("moment_gif_url");
+
     if (inputElement) {
-        inputElement.value = gifUrl;
+      inputElement.value = this.urlValue;
+
+      const previousGifElement = document.querySelector(".individual-gif.border-4.border-blue-500");
+
+      if (previousGifElement) {
+        previousGifElement.classList.remove("border-4", "border-blue-500");
+      }
+
+      this.gifTarget.classList.add("border-4", "border-blue-500");
     }
   }
 }

--- a/app/views/moments/_form.html.erb
+++ b/app/views/moments/_form.html.erb
@@ -14,18 +14,17 @@
   <div class="my-5">
     <%= form.label :wassup, "Wassup? 👋" %>
     <%= form.text_field :wassup,
+      placeholder: "Just chilling...",
       data: { controller: "moment", action: "input->moment#searchGif" },
       class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
   </div>
 
   <div class="my-5">
-    <%= form.label :gif_url, "GIF URL" %>
-    <%= form.text_field :gif_url, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%= form.hidden_field :gif_url, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
   </div>
 
-
   <%= turbo_frame_tag :search_gif_results do %>
-   <%= render partial: "moments/search_gif", locals: { gifs: @gifs } %>
+    <%= render partial: "moments/search_gif", locals: { gifs: @gifs } %>
   <% end %>
 
   <div class="inline">

--- a/app/views/moments/_search_gif.html.erb
+++ b/app/views/moments/_search_gif.html.erb
@@ -1,7 +1,11 @@
-<div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4" data-controller="select-gif">
+<div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4">
   <% @gifs&.each do |gif| %>
-    <div class="mb-4" data-action="click->select-gif#selectGif" data-gif-url="<%= gif[:tinygif] %>">
-      <%= image_tag gif[:tinygif], class: "rounded-lg" %>
+    <div class="mb-4 individual-gif"
+      data-controller="select-gif"
+      data-select-gif-target="gif"
+      data-action="click->select-gif#selectGif"
+      data-select-gif-url-value="<%= gif[:tinygif] %>">
+      <%= image_tag gif[:tinygif], class: "cursor-pointer" %>
     </div>
   <% end %>
 </div>

--- a/app/views/moments/search_gif.turbo_stream.erb
+++ b/app/views/moments/search_gif.turbo_stream.erb
@@ -1,12 +1,6 @@
 <%= turbo_stream.replace :search_gif_results do %>
   <%= turbo_frame_tag :search_gif_results do %>
-
-  <p class="pb-4">
-    Right click on the GIF and select "Copy image address" to get the GIF URL.
-    Sorry for the hassle, I'm working on a better solution. 🙏
-  </p>
-
-
-  <%= render partial: "moments/search_gif", locals: { gifs: @gifs } %>
+    <p class="pb-4">Choose a GIF to go with your moment</p>
+    <%= render partial: "moments/search_gif", locals: { gifs: @gifs } %>
   <% end %>
 <% end %>


### PR DESCRIPTION
We have added the ability to select a GIF in #1. 

Now we can also keep the URL as a hidden field as it’s not really needed to be shown. 

This PR also adds a border to the GIF on selection to indicate which one is selected.